### PR TITLE
BUGFIX: Fixed issue where GA4 keys were not being swapped out in non-live modes

### DIFF
--- a/src/AnalyticsJS.php
+++ b/src/AnalyticsJS.php
@@ -231,7 +231,7 @@ class AnalyticsJS extends Extension
                 // Replace Tracker IDs with fake ones if not in LIVE mode
                 if ($skip_tracking) {
                     $conf[1] = preg_replace(
-                        '/[0-9]{4,}-[0-9]+/',
+                        '/([0-9]{4,}-[0-9]+)|((?!=G-)[0-9A-Z]{10,})/',
                         'DEV-' . $this->tracker_counter++,
                         $conf[1]
                     );


### PR DESCRIPTION
Due to a change in the pattern for GA4 keys the old RegEx used to swap out the keys in dev mode would not detect and properly replace GA4 keys. This pull request updates the expression to include support for GA4 keys.